### PR TITLE
Test on coreBrowserSet instead of browserIgnoreList

### DIFF
--- a/scripts/baseline/calculate-status.ts
+++ b/scripts/baseline/calculate-status.ts
@@ -2,8 +2,6 @@ import { browser, Browser } from "../../src/browser-compat-data/browser";
 import { feature } from "../../src/browser-compat-data/feature";
 import { Release } from "../../src/browser-compat-data/release";
 
-const browserIgnoreList = [browser("ie")];
-
 export type StatusReport = {
   id: string;
   baseline: "low" | "high" | false;
@@ -100,7 +98,7 @@ function supportIntroduced(
 export function reportFeature(id: string): StatusReport {
   const feat = feature(id);
 
-  const supportingReleases = feat.supportedBy({ omit: browserIgnoreList });
+  const supportingReleases = feat.supportedBy({ only: coreBrowserSet });
   const coreBrowserSetReleases = supportingReleases.filter((rel) =>
     coreBrowserSet.includes(rel.browser),
   );

--- a/src/baseline/index.ts
+++ b/src/baseline/index.ts
@@ -65,7 +65,7 @@ function calculate(compatKey: string, compat: Compat): SupportStatus {
   const f = feature(compatKey);
   const s = support(f, browsers(compat), compat);
 
-  const allReleases = f.supportedBy({ compat });
+  const allReleases = f.supportedBy({ only: browsers(compat), compat });
   const isBaselineLow = lowReleases(compat).every((r) =>
     allReleases.includes(r),
   );


### PR DESCRIPTION
Hey @ddbeck! I was looking at unresolved BCD data in https://docs.google.com/spreadsheets/d/1RVgaq4ruHYeJvLCky-h2VAreRP5j_CKifaBvwYEhsL0/edit#gid=1279455993&fvid=1437656086

The first row is `api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch`.

<details><summary>BCD statement</summary>
<p>

```json
 "support": {
                "chrome": {
                  "version_added": "55"
                },
                "chrome_android": {
                  "version_added": "55"
                },
                "deno": {
                  "version_added": null
                },
                "edge": {
                  "version_added": "79"
                },
                "firefox": {
                  "version_added": "61"
                },
                "firefox_android": {
                  "version_added": "61"
                },
                "ie": {
                  "version_added": false
                },
                "nodejs": {
                  "version_added": false
                },
                "oculus": {
                  "version_added": "5.0"
                },
                "opera": {
                  "version_added": "42"
                },
                "opera_android": {
                  "version_added": "42"
                },
                "safari": {
                  "version_added": "11.1"
                },
                "safari_ios": {
                  "version_added": "11.3"
                },
                "samsunginternet_android": {
                  "version_added": "6.0"
                },
                "webview_android": {
                  "version_added": "55"
                }
              }
```

</p>
</details> 


I ran `npx tsx ./scripts/baseline/ api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch`

I got a 

<details><summary>Stacktrace</summary>
<p>

/Users/florianscholz/dev/strict-browser-compat-data/src/browser-compat-data/feature.ts:78
        throw Error(
              ^
Error: function feature(id,data){if(data){return new Feature(id,data)}const lookup=knownFeatures.get(id);if(lookup){return lookup}const f=new Feature(id,data);knownFeatures.set(id,f);return f} contains non-real values. Cannot expand support.
    at Feature._supportedBy (/Users/florianscholz/dev/strict-browser-compat-data/src/browser-compat-data/feature.ts:78:15)
    at Feature.supportedBy (/Users/florianscholz/dev/strict-browser-compat-data/src/browser-compat-data/feature.ts:109:29)
    at reportFeature (/Users/florianscholz/dev/strict-browser-compat-data/scripts/baseline/calculate-status.ts:103:35)
    at <anonymous> (/Users/florianscholz/dev/strict-browser-compat-data/scripts/baseline/index.ts:63:36)
    at Array.map (<anonymous>)
    at Object.main (/Users/florianscholz/dev/strict-browser-compat-data/scripts/baseline/index.ts:63:25)
    at Object.runCommand (file:///Users/florianscholz/dev/strict-browser-compat-data/node_modules/yargs/build/lib/command.js:174:48)
    at Object.parseArgs [as _parseArgs] (file:///Users/florianscholz/dev/strict-browser-compat-data/node_modules/yargs/build/lib/yargs-factory.js:1001:51)
    at Object.get [as argv] (file:///Users/florianscholz/dev/strict-browser-compat-data/node_modules/yargs/build/lib/yargs-factory.js:946:25)
    at <anonymous> (/Users/florianscholz/dev/strict-browser-compat-data/scripts/baseline/index.ts:56:9)

</p>
</details> 

The error message is "contains non-real values. Cannot expand support.". 

So, well yes, deno has a non-real value here, but that should **not** matter for baseline calculation, should it? (see the BCD statement above)

I thought I could fix the issue and so this PR does a tweak to the script to only test the core browser set. Maybe I'm totally wrong with this fix but hopefully you can tell me what is going on here.